### PR TITLE
Add background to svg for better look in dark mode

### DIFF
--- a/assets/icons/GitHub-Mark.svg
+++ b/assets/icons/GitHub-Mark.svg
@@ -5,6 +5,7 @@
  width="427.000000pt" height="413.000000pt" viewBox="0 0 427.000000 413.000000"
  preserveAspectRatio="xMidYMid meet">
 
+<rect width="100%" height="100%" fill="#FFFFFF" />
 <g transform="translate(0.000000,413.000000) scale(0.100000,-0.100000)"
 fill="#000000" stroke="none">
 <path d="M1921 4089 c-638 -67 -1230 -437 -1565 -979 -425 -687 -419 -1548 17


### PR DESCRIPTION
Added a white background (using `fill` in `<rect />`) to the GitHub logo svg since it's difficult to see in dark mode on GitHub with a transparent background.